### PR TITLE
Fix for async_get_registry issue #19

### DIFF
--- a/custom_components/auto_areas/__init__.py
+++ b/custom_components/auto_areas/__init__.py
@@ -40,7 +40,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     _LOGGER.debug("Found config %s", auto_areas_config)
 
-    area_registry: AreaRegistry = await hass.helpers.area_registry.async_get_registry()
+    area_registry: AreaRegistry = hass.helpers.area_registry.async_get(hass)
 
     auto_areas: MutableMapping[str, AutoArea] = {}
 

--- a/custom_components/auto_areas/auto_area.py
+++ b/custom_components/auto_areas/auto_area.py
@@ -30,21 +30,21 @@ class AutoArea(object):
         self.entities: Set[RegistryEntry] = set()
 
         if self.hass.is_running:
-            self.hass.async_create_task(self.initialize())
+            self.hass.async_create_task(self.initialize(hass))
         else:
             self.hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STARTED, self.initialize()
+                EVENT_HOMEASSISTANT_STARTED, self.initialize(hass)
             )
 
-    async def initialize(self) -> None:
+    async def initialize(self, hass) -> None:
         """Register relevant entities for this area"""
         _LOGGER.info("AutoArea '%s' (config %s)", self.area_name, self.config)
 
         entity_registry: EntityRegistry = (
-            await self.hass.helpers.entity_registry.async_get_registry()
+            self.hass.helpers.entity_registry.async_get(hass)
         )
         device_registry: DeviceRegistry = (
-            await self.hass.helpers.device_registry.async_get_registry()
+            self.hass.helpers.device_registry.async_get(hass)
         )
 
         # Collect entities for this area

--- a/custom_components/auto_areas/binary_sensor.py
+++ b/custom_components/auto_areas/binary_sensor.py
@@ -26,10 +26,10 @@ async def async_setup_platform(
     """Set up all binary_sensors"""
     area_registry: AreaRegistry = hass.helpers.area_registry.async_get(hass)
     entity_registry: EntityRegistry = (
-        hass.helpers.entity_registry.async_get_registry(hass)
+        hass.helpers.entity_registry.async_get(hass)
     )
     device_registry: DeviceRegistry = (
-        hass.helpers.device_registry.async_get_registry(hass)
+        hass.helpers.device_registry.async_get(hass)
     )
 
     binary_sensor_entities = []

--- a/custom_components/auto_areas/binary_sensor.py
+++ b/custom_components/auto_areas/binary_sensor.py
@@ -24,12 +24,12 @@ async def async_setup_platform(
     discovery_info=None,
 ):
     """Set up all binary_sensors"""
-    area_registry: AreaRegistry = await hass.helpers.area_registry.async_get_registry()
+    area_registry: AreaRegistry = hass.helpers.area_registry.async_get(hass)
     entity_registry: EntityRegistry = (
-        await hass.helpers.entity_registry.async_get_registry()
+        hass.helpers.entity_registry.async_get_registry(hass)
     )
     device_registry: DeviceRegistry = (
-        await hass.helpers.device_registry.async_get_registry()
+        hass.helpers.device_registry.async_get_registry(hass)
     )
 
     binary_sensor_entities = []


### PR DESCRIPTION
async_get_registry is deprecated and has now been removed starting with Home Assistant 2023.5.0.