### PR TITLE
fix: debounce registry reloads and skip unrelated entity removals

### DIFF
--- a/custom_components/auto_areas/auto_area.py
+++ b/custom_components/auto_areas/auto_area.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 from collections.abc import Callable
 
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
 from homeassistant.helpers.area_registry import async_get as async_get_area_registry
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.issue_registry import async_create_issue, IssueSeverity
 from homeassistant.config_entries import ConfigEntry
@@ -66,6 +67,8 @@ class AutoArea:
 
         self.auto_lights = None
         self._registry_unsubs: list[Callable[[], None]] = []
+        self._known_entity_ids: set[str] = set()
+        self._reload_debounce_cancel: CALLBACK_TYPE | None = None
 
     async def async_initialize(self):
         """Subscribe to area changes and reload if necessary."""
@@ -75,6 +78,10 @@ class AutoArea:
         )
         self.auto_lights = AutoLights(self)
         await self.auto_lights.initialize()
+
+        self._known_entity_ids = {
+            e.entity_id for e in self.get_valid_entities()
+        }
 
         self._registry_unsubs.append(
             self.hass.bus.async_listen(
@@ -97,15 +104,15 @@ class AutoArea:
         entity_id = data.get("entity_id", "")
         entity = self.entity_registry.async_get(entity_id)
         if entity is None:
-            # Entity was removed — check old_entity_id for area match
-            if data.get("action") == "remove":
+            # Entity was removed — only reload if it belonged to this area
+            if data.get("action") == "remove" and entity_id in self._known_entity_ids:
                 LOGGER.debug(
-                    "%s: Entity removed, reloading",
+                    "%s: Known entity %s removed, scheduling reload",
                     self.area_name,
+                    entity_id,
                 )
-                await self.hass.config_entries.async_reload(
-                    self.config_entry.entry_id
-                )
+                self._known_entity_ids.discard(entity_id)
+                await self._schedule_reload()
             return
         # Skip our own entities to avoid infinite reload loops
         if entity.platform == DOMAIN:
@@ -113,24 +120,39 @@ class AutoArea:
         from .ha_helpers import get_area_id
         if get_area_id(entity, self.device_registry) == self.area_id:
             LOGGER.debug(
-                "%s: Entity registry change for %s, reloading",
+                "%s: Entity registry change for %s, scheduling reload",
                 self.area_name,
                 entity_id,
             )
-            await self.hass.config_entries.async_reload(
-                self.config_entry.entry_id
-            )
+            await self._schedule_reload()
 
     async def _handle_area_registry_updated(self, event: Event) -> None:
         """Reload when this area is updated."""
         if event.data.get("area_id") == self.area_id:
             LOGGER.debug(
-                "%s: Area registry updated, reloading",
+                "%s: Area registry updated, scheduling reload",
                 self.area_name,
             )
-            await self.hass.config_entries.async_reload(
-                self.config_entry.entry_id
-            )
+            await self._schedule_reload()
+
+    async def _schedule_reload(self) -> None:
+        """Schedule a debounced reload."""
+        if self._reload_debounce_cancel:
+            self._reload_debounce_cancel()
+        self._reload_debounce_cancel = async_call_later(
+            self.hass,
+            0.2,
+            self._do_reload,
+        )
+
+    async def _do_reload(self, _now=None) -> None:
+        """Execute the actual reload."""
+        self._reload_debounce_cancel = None
+        self._known_entity_ids = {
+            e.entity_id for e in self.get_valid_entities()
+        }
+        LOGGER.debug("%s: Reloading config entry", self.area_name)
+        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
     def cleanup(self):
         """Deinitialize this area."""
@@ -138,6 +160,9 @@ class AutoArea:
             "%s: Disabling area control",
             self.area_name
         )
+        if self._reload_debounce_cancel:
+            self._reload_debounce_cancel()
+            self._reload_debounce_cancel = None
         for unsub in self._registry_unsubs:
             unsub()
         self._registry_unsubs.clear()


### PR DESCRIPTION
## Registry reload improvements

Two performance fixes for `auto_area.py`:

### 1. Skip unrelated entity removals
Previously, any entity removal anywhere in HA triggered a reload in every auto_areas instance, regardless of whether it was related to that area.

**Fix:** Each `AutoArea` now tracks `_known_entity_ids` — the set of entity IDs it manages. On "remove" events, only reloads if the entity was actually in its set.

### 2. Debounced reloads (200ms)
Multiple rapid registry events (e.g. HA startup, bulk area changes) previously caused a storm of sequential reloads. Each event triggered its own `async_reload` call.

**Fix:** All reload calls go through `_schedule_reload()` which uses `async_call_later(0.2s)`. Multiple events within 200ms collapse into a single reload.

### Details
- `_known_entity_ids` is built at init and refreshed before each reload
- Debounce timer is cancelled in `cleanup()`
- No behaviour change for normal usage — just fewer unnecessary reloads

**129 tests passing, ruff clean.**