### PR TITLE
fix: don't drive light group for areas without lights

### DIFF
--- a/custom_components/auto_areas/auto_lights.py
+++ b/custom_components/auto_areas/auto_lights.py
@@ -199,7 +199,26 @@ class AutoLights:
                 )
             await self._turn_lights_off()
 
+    def _light_group_available(self) -> bool:
+        """Return True if the area's light group entity exists.
+
+        The light group is only created for areas that actually have lights
+        (see light.py). Areas without lights, or a group that hasn't finished
+        setting up yet, would otherwise cause "Referenced entities ... are
+        missing or not currently available" warnings on every service call.
+        """
+        if self.hass.states.get(self.light_group_entity_id) is None:
+            LOGGER.debug(
+                "%s: No light group (%s) to control, skipping",
+                self.auto_area.area_name,
+                self.light_group_entity_id,
+            )
+            return False
+        return True
+
     async def _turn_lights_on(self):
+        if not self._light_group_available():
+            return
         await self.hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
@@ -208,6 +227,8 @@ class AutoLights:
         self.lights_turned_on = True
 
     async def _turn_lights_off(self):
+        if not self._light_group_available():
+            return
         self._auto_turning_off = True
         try:
             await self.hass.services.async_call(

--- a/tests/test_auto_lights.py
+++ b/tests/test_auto_lights.py
@@ -48,10 +48,21 @@ def _make_auto_area(area_name="living_room", options=None):
     return auto_area
 
 
-def _create_auto_lights(auto_area):
-    """Create an AutoLights instance."""
+def _create_auto_lights(auto_area, with_light_group=True):
+    """Create an AutoLights instance.
+
+    By default registers the area's light group in the mock state map, so that
+    tests exercise a normal area that actually has lights. Pass
+    ``with_light_group=False`` to simulate an area without any light entities
+    (no group exists), which AutoLights must not try to control.
+    """
     from custom_components.auto_areas.auto_lights import AutoLights
-    return AutoLights(auto_area)
+    lights = AutoLights(auto_area)
+    if with_light_group:
+        auto_area._states_map[lights.light_group_entity_id] = _make_state(
+            lights.light_group_entity_id, STATE_OFF
+        )
+    return lights
 
 
 class TestAutoLightsPresence:
@@ -132,6 +143,44 @@ class TestAutoLightsPresence:
         lights = _create_auto_lights(auto_area)
 
         event = _make_event(lights.presence_entity_id, STATE_ON, None)
+
+        await lights.handle_presence_state_change(event)
+
+        auto_area.hass.services.async_call.assert_not_called()
+
+
+class TestAutoLightsNoLightGroup:
+    """Areas without lights have no light group; AutoLights must not drive it.
+
+    Regression: a light group is only created when the area has at least one
+    light entity, but AutoLights is set up for every area. Calling
+    light.turn_on/off on a non-existent group logs
+    "Referenced entities light.area_lights_<area> are missing or not currently
+    available" on every presence change.
+    """
+
+    @pytest.mark.asyncio
+    async def test_turn_on_skipped_when_light_group_missing(self):
+        """No service call when presence is detected but no light group exists."""
+        auto_area = _make_auto_area()
+        lights = _create_auto_lights(auto_area, with_light_group=False)
+        lights.sleep_mode_enabled = False
+
+        event = _make_event(lights.presence_entity_id, STATE_OFF, STATE_ON)
+
+        await lights.handle_presence_state_change(event)
+
+        auto_area.hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_skipped_when_light_group_missing(self):
+        """No service call when presence clears but no light group exists."""
+        auto_area = _make_auto_area()
+        lights = _create_auto_lights(auto_area, with_light_group=False)
+        lights.sleep_mode_enabled = False
+        lights.lights_turned_on = True
+
+        event = _make_event(lights.presence_entity_id, STATE_ON, STATE_OFF)
 
         await lights.handle_presence_state_change(event)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -82,6 +82,44 @@ async def test_light_group_is_created(
 
 
 @pytest.mark.asyncio
+async def test_no_light_service_calls_for_area_without_lights(
+    hass: HomeAssistant,
+    test_area: ar.AreaEntry,
+    motion_sensor: str,
+    config_entry: MockConfigEntry,
+):
+    """Areas without lights must not issue light service calls.
+
+    Regression: the light group is only created when an area has lights, but
+    AutoLights runs for every area. Driving presence in a light-less area used
+    to call light.turn_on/off on a non-existent group, logging
+    "Referenced entities light.area_lights_test_room are missing or not
+    currently available" on every presence change.
+    """
+    from homeassistant.const import STATE_OFF, STATE_ON
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    await hass.async_block_till_done()
+
+    # Sanity: this area has no lights, so no light group should exist.
+    assert hass.states.get("light.area_lights_test_room") is None
+
+    turn_on = async_mock_service(hass, "light", "turn_on")
+    turn_off = async_mock_service(hass, "light", "turn_off")
+
+    # Drive presence off -> on -> off to exercise turn on/off paths.
+    hass.states.async_set(motion_sensor, STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set(motion_sensor, STATE_ON)
+    await hass.async_block_till_done()
+    hass.states.async_set(motion_sensor, STATE_OFF)
+    await hass.async_block_till_done()
+
+    assert not turn_on, "light.turn_on called for an area with no light group"
+    assert not turn_off, "light.turn_off called for an area with no light group"
+
+
+@pytest.mark.asyncio
 async def test_config_entry_unloads_cleanly(
     hass: HomeAssistant,
     test_area: ar.AreaEntry,


### PR DESCRIPTION
## Problem

`AutoLights` is set up for **every** area, but the light group entity `light.area_lights_<area>` is only created when the area actually has light entities (`light.py` skips group creation when `light_entity_ids` is empty).

As a result, areas without lights — or a group still finishing setup during startup — caused `light.turn_on`/`light.turn_off` calls against a non-existent entity, logging on **every presence change**:

```
Referenced entities light.area_lights_<area> are missing or not currently available
```

This also contributed to `Module custom_components.auto_areas is logging too frequently` throttle warnings at startup.

## Fix

Guard `_turn_lights_on` / `_turn_lights_off` with a `_light_group_available()` check that skips (debug-logs) when the group entity doesn't exist. No behavior change for normal areas that have a light group — the group is always present there, so the guard is a no-op.

## Tests

- Unit tests: no `light` service call fires when there's no light group (turn-on and turn-off paths).
- Integration test: a light-less area issues no `light.turn_on/off` calls across presence off→on→off. Verified it fails without the guard and passes with it.
- Full suite: 132 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)