### PR TITLE
fix: apply initial light state after platforms are set up (2.9.5)

### DIFF
--- a/custom_components/auto_areas/__init__.py
+++ b/custom_components/auto_areas/__init__.py
@@ -59,8 +59,15 @@ async def async_init(hass: HomeAssistant, entry: ConfigEntry, auto_area: AutoAre
     # Wait briefly for all area devices/entities to finish registering before
     # building groups. async_block_till_done() can deadlock here during startup.
     await asyncio.sleep(2)
-    await auto_area.async_initialize()
+    # Set up platforms first so the aggregate entities (light group, presence
+    # sensor, ...) exist and are available before AutoLights applies the initial
+    # light state. Doing this the other way around makes async_initialize call
+    # light.turn_on/off against a not-yet-created group, which on restart also
+    # sees the entity's restored (unavailable) placeholder state and logs
+    # "Referenced entities light.area_lights_<area> are missing or not currently
+    # available".
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await auto_area.async_initialize()
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 

--- a/custom_components/auto_areas/auto_lights.py
+++ b/custom_components/auto_areas/auto_lights.py
@@ -4,6 +4,8 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.core import Event, EventStateChangedData
 from homeassistant.const import (
     STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     SERVICE_TURN_ON,
     SERVICE_TURN_OFF,
     ATTR_ENTITY_ID,
@@ -200,18 +202,22 @@ class AutoLights:
             await self._turn_lights_off()
 
     def _light_group_available(self) -> bool:
-        """Return True if the area's light group entity exists.
+        """Return True if the area's light group entity exists and is available.
 
         The light group is only created for areas that actually have lights
-        (see light.py). Areas without lights, or a group that hasn't finished
-        setting up yet, would otherwise cause "Referenced entities ... are
-        missing or not currently available" warnings on every service call.
+        (see light.py). Areas without lights have no group at all. On restart the
+        entity registry also yields a restored (``unavailable``) placeholder
+        before the light platform re-creates the group. Calling light.turn_on/off
+        in either case logs "Referenced entities ... are missing or not currently
+        available", so skip while the group is absent or not yet available.
         """
-        if self.hass.states.get(self.light_group_entity_id) is None:
+        state = self.hass.states.get(self.light_group_entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             LOGGER.debug(
-                "%s: No light group (%s) to control, skipping",
+                "%s: Light group (%s) not available (%s), skipping",
                 self.auto_area.area_name,
                 self.light_group_entity_id,
+                state.state if state else "missing",
             )
             return False
         return True

--- a/custom_components/auto_areas/manifest.json
+++ b/custom_components/auto_areas/manifest.json
@@ -23,5 +23,5 @@
   "documentation": "https://github.com/c-st/auto_areas",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/c-st/auto_areas/issues",
-  "version": "2.9.4"
+  "version": "2.9.5"
 }

--- a/tests/test_auto_lights.py
+++ b/tests/test_auto_lights.py
@@ -186,6 +186,43 @@ class TestAutoLightsNoLightGroup:
 
         auto_area.hass.services.async_call.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_turn_on_skipped_when_light_group_unavailable(self):
+        """No service call while the light group is unavailable.
+
+        On restart the entity registry yields a restored 'unavailable'
+        placeholder for the group before the light platform re-creates it.
+        """
+        auto_area = _make_auto_area()
+        lights = _create_auto_lights(auto_area, with_light_group=False)
+        lights.sleep_mode_enabled = False
+        auto_area._states_map[lights.light_group_entity_id] = _make_state(
+            lights.light_group_entity_id, "unavailable"
+        )
+
+        event = _make_event(lights.presence_entity_id, STATE_OFF, STATE_ON)
+
+        await lights.handle_presence_state_change(event)
+
+        auto_area.hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_skipped_when_light_group_unknown(self):
+        """No service call while the light group state is unknown."""
+        auto_area = _make_auto_area()
+        lights = _create_auto_lights(auto_area, with_light_group=False)
+        lights.sleep_mode_enabled = False
+        lights.lights_turned_on = True
+        auto_area._states_map[lights.light_group_entity_id] = _make_state(
+            lights.light_group_entity_id, "unknown"
+        )
+
+        event = _make_event(lights.presence_entity_id, STATE_ON, STATE_OFF)
+
+        await lights.handle_presence_state_change(event)
+
+        auto_area.hass.services.async_call.assert_not_called()
+
 
 class TestAutoLightsManualOverride:
     """Test manual light override prevents illuminance from turning lights back on."""


### PR DESCRIPTION
Follow-up to #238. Production restart logs showed the "missing or not currently available" warnings still firing for areas **with** lights, so the 2.9.4 guard was incomplete.

## Root cause (from live restart logs)

```
21:22:41.802  Bedroom: No initial presence detected. Turning lights off light.area_lights_bedroom
21:22:41.803  WARNING  Referenced entities light.area_lights_bedroom are missing or not currently available
21:22:41.936  Setting up auto_areas.light   ← group created AFTER the service call
```

1. **Ordering:** `async_init()` called `async_initialize()` (which applies the initial light state) *before* forwarding platform setups, so `light.turn_on/off` ran before the `light` platform created the group.
2. **Restored state:** on restart the entity registry yields a restored `unavailable` placeholder for the group, so the 2.9.4 group-missing guard (`is None`) passed and the service was still called.

## Fixes

- Forward platform setups **before** `async_initialize()`, so the light group (and presence sensor) exist and are available first. Verified safe: platform setups only depend on the `AutoArea` in `hass.data`, not on `async_initialize`.
- Treat `unavailable`/`unknown` group state as "not available" in the guard.

## Tests

- New unit tests for the `unavailable`/`unknown` group cases.
- Full suite: 134 passed; ruff clean.

Version bumped to 2.9.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)